### PR TITLE
Entrypoint rewrite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,27 @@
-FROM debian:bookworm
-RUN apt update && apt install -y jq curl xz-utils xvfb
-RUN MAPSHOT_VERSION=`curl -s https://api.github.com/repos/Palats/mapshot/releases/latest | jq .tag_name | sed 's/\"//g'` && curl -s -L -o /usr/local/bin/mapshot https://github.com/Palats/mapshot/releases/download/$MAPSHOT_VERSION/mapshot-linux && chmod +x /usr/local/bin/mapshot
-RUN mkdir -p /mapshot
-COPY entrypoint.sh /entrypoint.sh
+FROM debian:bookworm-slim
+
+RUN apt update && apt install --yes \
+        jq \
+        curl \
+        xz-utils \
+        xvfb
+RUN rm --recursive --force /var/lib/apt/lists/*
+
+RUN MAPSHOT_VERSION="$(curl --silent https://api.github.com/repos/Palats/mapshot/releases/latest | jq --raw-output .tag_name)" && \
+        curl --location --silent --output /usr/local/bin/mapshot "https://github.com/Palats/mapshot/releases/download/${MAPSHOT_VERSION}/mapshot-linux" && \
+        chmod +x /usr/local/bin/mapshot
+
+RUN groupadd --gid 1001 mapshot && \
+        useradd --uid 1001 --gid 1001 --home /opt/mapshot --shell /usr/sbin/nologin mapshot && \
+        mkdir --parents /opt/mapshot && \
+        chown --recursive mapshot:mapshot /opt/mapshot
+RUN mkdir --parents /opt/mapshot
+
+COPY src/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-ENTRYPOINT [ "/bin/bash", "-c", "/entrypoint.sh" ]
+
+USER mapshot
+
+WORKDIR /opt/mapshot
+
+ENTRYPOINT ["/bin/bash", "-ceuo", "pipefail", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN groupadd --gid 1001 mapshot && \
         useradd --uid 1001 --gid 1001 --home /opt/mapshot --shell /usr/sbin/nologin mapshot && \
         mkdir --parents /opt/mapshot && \
         chown --recursive mapshot:mapshot /opt/mapshot
-RUN mkdir --parents /opt/mapshot
 
 COPY src/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ The following environment variables are used in the provided shell script, and h
 | MAPSHOT_SAVE_NAME                     | N/A                                                 | Specifies the name of the save file to use for rendering. If not set, the default save file is used. |
 | FACTORIO_RELEASE                      | "stable"                                            | Determines which release of Factorio to use. Options include "stable" and "experimental". |
 | FACTORIO_AUTO_UPDATE                  | "true"                                              | If set to "true," automatically updates Factorio to the latest release within the specified release tier. |
-| FACTORIO_SAVE                         | "/opt/factorio/saves/dummy.zip"                     | Specifies the full path to the Factorio save file that will be used for map rendering. This is the save file the mapshot tool will render into an image. |
+| FACTORIO_SAVE                         | "/opt/factorio/saves/dummy.zip"                     | Specifies the full path to the Factorio save file that will be used for map rendering. Can also be a `http(s)://` address pointing to a the `.zip` file. This is the save file the mapshot tool will render into an image. |
 | FACTORIO_SAVE_PATH                    | The directory containing "${FACTORIO_SAVE}"         | Specifies the directory where Factorio save files are stored. |
 
-When using `MAPSHOT_SAVE_MODE="latest` the generated Mapshots will likely be named like: `_autosave1`,`_autosave2`,`_autosave3` etc.  
-Combining `MAPSHOT_SAVE_MODE="latest` with `MAPSHOT_SAVE_NAME="mysave"` the generated Mapshots will be named `mysave`.
+When using `MAPSHOT_SAVE_MODE="latest"` the generated Mapshots will likely be named like: `_autosave1`,`_autosave2`,`_autosave3` etc.  
+Combining `MAPSHOT_SAVE_MODE="latest"` with `MAPSHOT_SAVE_NAME="mysave"` the generated Mapshots will be named `mysave`.
 
 ## Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -17,25 +17,24 @@ Several default paths and settings are configurable via environment variables, a
 
 The following environment variables are used in the provided shell script, and here is a description of each one, explaining what it does:
 
-| Environment Variable                  | Default Value                                       | Description                                                                                                                                          |
-| ------------------------------------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MAPSHOT_ROOT_DIRECTORY                | "/mapshot"                                          | Defines the root directory where Factorio files and related data are located. Defaults to /mapshot if not set.                                       |
-| FACTORIO_USERNAME                     | N/A                                                 | The username required to authenticate with Factorio's website to download Factorio game files.                                                       |
-| FACTORIO_TOKEN                        | N/A                                                 | The authentication token associated with the user, used in conjunction with FACTORIO_USERNAME to authenticate Factorio downloads.                    |
-| MAPSHOT_FACTORIO_DATA_DIRECTORY       | "$MAPSHOT_ROOT_DIRECTORY/factorio"                  | Specifies the directory where Factorio data (saves, mods, etc.) is stored. Defaults to $MAPSHOT_ROOT_DIRECTORY/factorio if not set.                  |
-| MAPSHOT_FACTORIO_BINARY_PATH          | "$MAPSHOT_ROOT_DIRECTORY/factorio/bin/x64/factorio" | Defines the path to the Factorio binary (executable). Defaults to $MAPSHOT_ROOT_DIRECTORY/factorio/bin/x64/factorio if not set.                      |
-| MAPSHOT_MODE                          | N/A                                                 | Determines the script's operation mode: "render" for rendering maps or "serve" for starting a Factorio server to serve the map.                      |
-| MAPSHOT_WORKING_DIRECTORY             | "$MAPSHOT_ROOT_DIRECTORY/factorio"                  | Defines the working directory for temporary files during Factorio operations. Defaults to $MAPSHOT_ROOT_DIRECTORY/factorio if not set.               |
-| MAPSHOT_AREA                          | "all"                                               | Specifies which area of the map to render. Defaults to "all", meaning the entire map is rendered.                                                    |
-| MAPSHOT_MINIMUM_TILES                 | 64                                                  | Defines the minimum number of tiles used for map rendering. Controls the map's resolution.                                                           |
-| MAPSHOT_MAXIMUM_TILES                 | 0                                                   | Defines the maximum number of tiles used for rendering. A value of 0 means no limit.                                                                 |
-| MAPSHOT_JPEG_QUALITY                  | 90                                                  | Controls the quality of the rendered map in JPEG format. The value is a percentage, where a higher value results in better quality but larger files. |
-| MAPSHOT_MINIMUM_JPEG_QUALITY          | 90                                                  | Specifies the minimum JPEG quality for rendered images. The script will adjust the image quality if it falls below this threshold.                   |
-| MAPSHOT_SURFACES_TO_RENDER            | "all_"                                              | Determines which surfaces of the Factorio map to render. Defaults to all surfaces (*all*). Can be set to specific surfaces (e.g., "nauvis").         |
-| MAPSHOT_VERBOSE_FACTORIO_LOGGING      | Not set (optional)                                  | Enables verbose logging for Factorio during rendering or serving. If set, the script will include the --factorio_verbose flag.                       |
-| MAPSHOT_VERBOSE_MAPSHOT_LOG_LEVEL_INT | 9                                                   | Controls the verbosity of the mapshot tool's logging. The higher the number, the more detailed the logs. Defaults to 9, the most detailed log level. |
-| MAPSHOT_INTERVAL                      | 600                                                 | Defines the interval (in seconds) between map renders when the script is running in render mode. A higher value means fewer renders.                 |
-| FACTORIO_SAVE                         | N/A                                                 | Specifies the path to the Factorio save file that will be used for map rendering. This is the save file the mapshot tool will render into an image.  |
+| Environment Variable                  | Default Value                                       | Description                                       |
+| ------------------------------------- | --------------------------------------------------- | --------------------------------------------------- |
+| MAPSHOT_PREFIX                        | "mapshot"                                           | Mapshot will prefix all files it creates with that value. |
+| MAPSHOT_ROOT_DIRECTORY                | "/opt/mapshot"                                      | Defines the root directory where Mapshot and Factorio data are stored. |
+| MAPSHOT_FACTORIO_DATA_DIRECTORY       | "${MAPSHOT_ROOT_DIRECTORY}/factorio"                | Specifies the directory where Factorio data (saves, mods, etc.) is stored. |
+| MAPSHOT_FACTORIO_BINARY_PATH          | "${MAPSHOT_ROOT_DIRECTORY}/factorio/bin/x64/factorio" | Defines the path to the Factorio binary (executable). |
+| MAPSHOT_WORKING_DIRECTORY             | "${MAPSHOT_ROOT_DIRECTORY}"                         | Defines the working directory for temporary files during Factorio operations. |
+| MAPSHOT_KEEP_ONLY_LATEST              | "false"                                             | When set to "true," ensures that only the latest map rendering is kept, deleting older renders. |
+| MAPSHOT_INTERVAL                      | 600                                                 | Defines the interval (in seconds) between map renders when the script is running in render mode. A higher value means fewer renders. |
+| MAPSHOT_SAVE_MODE                     | N/A                                                 | When set to "latest", the `MAPSHOT_SAVE_NAME` variable is ignored, and the most recently modified save file in `FACTORIO_SAVE_PATH` is automatically discovered and used based on its modification time. |
+| MAPSHOT_SAVE_NAME                     | N/A                                                 | Specifies the name of the save file to use for rendering. If not set, the default save file is used. |
+| FACTORIO_RELEASE                      | "stable"                                            | Determines which release of Factorio to use. Options include "stable" and "experimental". |
+| FACTORIO_AUTO_UPDATE                  | "true"                                              | If set to "true," automatically updates Factorio to the latest release within the specified release tier. |
+| FACTORIO_SAVE                         | "/opt/factorio/saves/dummy.zip"                     | Specifies the full path to the Factorio save file that will be used for map rendering. This is the save file the mapshot tool will render into an image. |
+| FACTORIO_SAVE_PATH                    | The directory containing "${FACTORIO_SAVE}"         | Specifies the directory where Factorio save files are stored. |
+
+When using `MAPSHOT_SAVE_MODE="latest` the generated Mapshots will likely be named like: `_autosave1`,`_autosave2`,`_autosave3` etc.  
+Combining `MAPSHOT_SAVE_MODE="latest` with `MAPSHOT_SAVE_NAME="mysave"` the generated Mapshots will be named `mysave`.
 
 ## Docker Compose
 
@@ -61,8 +60,7 @@ services:
       MAPSHOT_INTERVAL: "600"
     volumes:
       - factorio-data:/opt/factorio:ro
-      - mapshot-data:/mapshot
-    restart: on-failure # Restart on failure (non-zero exit code)
+      - mapshot-data:/opt/mapshot
 
   mapshot-server:
     image: martydingo/mapshot:latest
@@ -72,7 +70,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - mapshot-data:/mapshot
+      - mapshot-data:/opt/mapshot
 
 volumes:
   factorio-data:
@@ -140,7 +138,7 @@ spec:
             - mountPath: /opt/factorio
               name: factorio-mapshot
               readOnly: true
-            - mountPath: /mapshot
+            - mountPath: /opt/mapshot
               name: mapshot-mapshot
         - name: mapshot-server
           image: martydingo/mapshot:latest
@@ -155,7 +153,7 @@ spec:
               protocol: TCP
               name: http
           volumeMounts:
-            - mountPath: /mapshot
+            - mountPath: /opt/mapshot
               name: mapshot-mapshot
       volumes:
         - name: factorio-mapshot

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,37 +1,344 @@
-echo "Checking if Factorio exists"
-if [ ! -f "${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"}/factorio/bin/x64/factorio" ]; then
-    echo "Factorio does not exist, downloading..."
-    if [[ -z $FACTORIO_USERNAME || -z $FACTORIO_TOKEN ]]; then
-        echo "Could not authenticate, cannot download without authentication, please confirm that environment variables FACTORIO_USERNAME & FACTORIO_TOKEN are set correctly"
-        echo "Current:"
-        echo "  FACTORIO_USERNAME: '$FACTORIO_USERNAME'"
-        echo "  FACTORIO_TOKEN: '$FACTORIO_TOKEN'"
-        echo "Exiting..."
-        exit
-    fi
-    curl "https://www.factorio.com/get-download/latest/expansion/linux64?username=$FACTORIO_USERNAME&token=$FACTORIO_TOKEN" -L -o /root/factorio-linux64.tar.xz
-    echo "Extracting..."
-    tar xvf /root/factorio-linux64.tar.xz -C ${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"} && mkdir -p ${MAPSHOT_FACTORIO_DATA_DIRECTORY:-"${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"}/factorio"}/mods && echo '{}' >${MAPSHOT_FACTORIO_DATA_DIRECTORY:-"${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"}/factorio"}/mods/mod-list.json
-else
-    echo "Factorio exists, proceeding without download"
-fi
+# Mapshot config variables
+MAPSHOT_PREFIX="${MAPSHOT_PREFIX:-"mapshot"}"
+MAPSHOT_ROOT_DIRECTORY="${MAPSHOT_ROOT_DIRECTORY:-"/opt/mapshot"}"
+MAPSHOT_FACTORIO_DATA_DIRECTORY="${MAPSHOT_FACTORIO_DATA_DIRECTORY:-"${MAPSHOT_ROOT_DIRECTORY}/factorio"}"
+MAPSHOT_FACTORIO_BINARY_PATH="${MAPSHOT_FACTORIO_BINARY_PATH:-"${MAPSHOT_ROOT_DIRECTORY}/factorio/bin/x64/factorio"}"
+MAPSHOT_WORKING_DIRECTORY="${MAPSHOT_WORKING_DIRECTORY:-"${MAPSHOT_ROOT_DIRECTORY}"}"
+MAPSHOT_KEEP_ONLY_LATEST="${MAPSHOT_KEEP_ONLY_LATEST:-"false"}"
+MAPSHOT_INTERVAL="${MAPSHOT_INTERVAL:-"600"}"
+MAPSHOT_SAVE_MODE="${MAPSHOT_SAVE_MODE:-}"
+MAPSHOT_SAVE_NAME="${MAPSHOT_SAVE_NAME:-}"
 
-if [ "$MAPSHOT_MODE" == "render" ]; then
-    if [ "$MAPSHOT_SAVE_MODE" == "latest" ]; then
-        echo 'MAPSHOT_SAVE_MODE set to latest, Discovering saves...'
-        FACTORIO_LATEST_SAVE=$(find /opt/factorio/saves/ -type f -exec ls -t {} \; 2>/dev/null | head -n 1)
-        echo "Using $FACTORIO_LATEST_SAVE"
-        echo 'Mapshot mode set to "render", rendering map...'
-        # Surfaces can be "nauvis"
-        timeout $MAPSHOT_INTERVAL xvfb-run mapshot render --logtostderr --factorio_binary ${MAPSHOT_FACTORIO_BINARY_PATH:-"${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"}/factorio/bin/x64/factorio"} --factorio_datadir ${MAPSHOT_FACTORIO_DATA_DIRECTORY:-"${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"}/factorio"} --work_dir ${MAPSHOT_WORKING_DIRECTORY:-"${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"}/factorio"} --area ${MAPSHOT_AREA:-"all"} --tilemin ${MAPSHOT_MINIMUM_TILES:-64} --tilemax ${MAPSHOT_MAXIMUM_TILES:-0} --jpgquality ${MAPSHOT_JPEG_QUALITY:-90} --minjpgquality ${MAPSHOT_MINIMUM_JPEG_QUALITY:-90} --surface ${MAPSHOT_SURFACES_TO_RENDER:-"_all_"} ${MAPSHOT_VERBOSE_FACTORIO_LOGGING:-"--factorio_verbose"} -v ${MAPSHOT_VERBOSE_MAPSHOT_LOG_LEVEL_INT:-9 } $FACTORIO_LATEST_SAVE
-    else
-        echo 'Mapshot mode set to "render", rendering map...'
-        # Surfaces can be "nauvis"
-        timeout $MAPSHOT_INTERVAL xvfb-run mapshot render --logtostderr --factorio_binary ${MAPSHOT_FACTORIO_BINARY_PATH:-"${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"}/factorio/bin/x64/factorio"} --factorio_datadir ${MAPSHOT_FACTORIO_DATA_DIRECTORY:-"${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"}/factorio"} --work_dir ${MAPSHOT_WORKING_DIRECTORY:-"${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"}/factorio"} --area ${MAPSHOT_AREA:-"all"} --tilemin ${MAPSHOT_MINIMUM_TILES:-64} --tilemax ${MAPSHOT_MAXIMUM_TILES:-0} --jpgquality ${MAPSHOT_JPEG_QUALITY:-90} --minjpgquality ${MAPSHOT_MINIMUM_JPEG_QUALITY:-90} --surface ${MAPSHOT_SURFACES_TO_RENDER:-"_all_"} ${MAPSHOT_VERBOSE_FACTORIO_LOGGING:-"--factorio_verbose"} -v ${MAPSHOT_VERBOSE_MAPSHOT_LOG_LEVEL_INT:-9 } $FACTORIO_SAVE
-    fi
-elif [ "$MAPSHOT_MODE" == "serve" ]; then
-    mapshot serve --factorio_binary ${MAPSHOT_FACTORIO_BINARY_PATH:-"${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"}/factorio/bin/x64/factorio"} --factorio_datadir ${MAPSHOT_FACTORIO_DATA_DIRECTORY:-"${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"}/factorio"} --work_dir ${MAPSHOT_WORKING_DIRECTORY:-"${MAPSHOT_ROOT_DIRECTORY:-"/mapshot"}/factorio"}
-else
-    echo 'Mapshot mode set to "serve", serving map...'
-    echo 'Please set environment variable $MAPSHOT_MODE to "render" or "serve", exiting..'
-fi
+# Factorio config variables
+FACTORIO_RELEASE="${FACTORIO_RELEASE:-"stable"}"
+FACTORIO_AUTO_UPDATE="${FACTORIO_AUTO_UPDATE:-"true"}"
+FACTORIO_SAVE="${FACTORIO_SAVE:-"/opt/factorio/saves/dummy.zip"}"
+FACTORIO_SAVE_PATH="${FACTORIO_SAVE_PATH:-$(dirname "${FACTORIO_SAVE}")}"
+
+# runtime variables
+MAPSHOT_FACTORIO_SCRIPT_OUTPUT_DIRECTORY="${MAPSHOT_FACTORIO_DATA_DIRECTORY}/script-output"
+MAPSHOT_OUTPUT_DIRECTORY="${MAPSHOT_FACTORIO_SCRIPT_OUTPUT_DIRECTORY}/${MAPSHOT_PREFIX}"
+FACTORIO_MODS_DIR="${MAPSHOT_FACTORIO_DATA_DIRECTORY}/mods"
+
+trap 'echo "Terminating script..."; exit 0' SIGTERM SIGINT
+
+get_available_factorio_versions() {
+	local updater_url="https://updater.factorio.com/get-available-versions?username=${FACTORIO_USERNAME}&token=${FACTORIO_TOKEN}"
+	local response http_status response_body
+
+	response=$(curl --location --silent --write-out "%{http_code}" "${updater_url}")
+	http_status="${response: -3}"
+	response_body="${response%???}"
+
+	if [[ "${http_status}" -ne 200 ]]; then
+		printf "Error: Received HTTP status '%s' from Factorio updater.\n" "${http_status}"
+		exit 1
+	fi
+
+	if ! { echo "${response_body}" | jq . >/dev/null 2>&1; }; then
+		printf "Error: Invalid JSON received from Factorio updater. Exiting...\n"
+		exit 1
+	fi
+
+	printf "%s" "${response_body}"
+}
+
+uninstall_factorio() {
+	printf "Cleaning up Factorio directory...\n"
+
+	if [[ -d "${MAPSHOT_FACTORIO_DATA_DIRECTORY}" ]]; then
+		find "${MAPSHOT_FACTORIO_DATA_DIRECTORY}" -mindepth 1 -type d -not -path "${MAPSHOT_OUTPUT_DIRECTORY}*" -exec rm --recursive --force {} +
+		find "${MAPSHOT_FACTORIO_DATA_DIRECTORY}" -mindepth 1 -type f -not -path "${MAPSHOT_OUTPUT_DIRECTORY}/*" -exec rm --force {} +
+
+		printf "Removed old Factorio installation\n"
+	else
+		printf "Factorio directory does not exist. Skipping cleanup.\n"
+	fi
+}
+
+download_factorio() {
+	local version="${1}"
+	local download_file="${MAPSHOT_ROOT_DIRECTORY}/factorio-linux64.tar.xz"
+	local download_url="https://www.factorio.com/get-download/${version}/expansion/linux64?username=${FACTORIO_USERNAME}&token=${FACTORIO_TOKEN}"
+
+	printf "Downloading Factorio version: %s...\n" "${version}"
+	http_status=$(curl --location --progress-bar --write-out "%{http_code}" --output "${download_file}" "${download_url}")
+
+	if [[ "${http_status}" -ne 200 ]]; then
+		printf "Error: Received HTTP status '%s' while attempting to download Factorio version: %s\n" "${http_status}" "${version}"
+		exit 1
+	fi
+
+	uninstall_factorio
+
+	printf "Extract Factorio version: %s..\n" "${version}"
+	tar --extract --xz --verbose --file "${download_file}" --directory "${MAPSHOT_ROOT_DIRECTORY}" || {
+		printf "Failed to extract Factorio archive.\n"
+		exit 1
+	}
+
+	rm --force "${download_file}"
+}
+
+validate_credentials() {
+	if [[ -z "${FACTORIO_USERNAME:-}" || -z "${FACTORIO_TOKEN:-}" ]]; then
+		printf "Authentication not possible. Please set FACTORIO_USERNAME and FACTORIO_TOKEN.\n"
+		exit 1
+	fi
+}
+
+calculate_md5() {
+	md5sum "${1}" | awk '{ print $1 }'
+}
+
+check_factorio_installation() {
+	local installed_factorio_version available_factorio_versions requested_factorio_version
+
+	printf "Checking if Factorio exists...\n"
+	if [[ ! -f "${MAPSHOT_FACTORIO_BINARY_PATH}" ]]; then
+		printf "Factorio does not exist, downloading...\n"
+
+		validate_credentials
+		download_factorio "${FACTORIO_RELEASE}"
+
+		mkdir --parents "${MAPSHOT_FACTORIO_SCRIPT_OUTPUT_DIRECTORY}"
+		mkdir --parents "${FACTORIO_MODS_DIR}"
+		echo '{}' >"${FACTORIO_MODS_DIR}/mod-list.json"
+	else
+		printf "Factorio exists, checking version...\n"
+
+		validate_credentials
+		installed_factorio_version="$(
+			"${MAPSHOT_FACTORIO_BINARY_PATH}" --version |
+				grep --only-matching --perl-regexp 'Version: \K\d+\.\d+\.\d+' ||
+				printf "Unable to determine the installed version.\n"
+			exit 1
+		)"
+
+		printf "Installed version: %s\n" "${installed_factorio_version}"
+
+		case "${FACTORIO_RELEASE}" in
+		"stable")
+			available_factorio_versions="$(get_available_factorio_versions | tail --lines 1)"
+			requested_factorio_version="$(
+				printf "%s" "${available_factorio_versions}" |
+					jq --raw-output '.["core-linux64"][] | select(.stable != null) | .stable'
+			)"
+			printf "Latest available stable Factorio version: %s\n" "${requested_factorio_version}"
+			;;
+		"latest")
+			available_factorio_versions="$(get_available_factorio_versions | tail --lines 1)"
+			requested_factorio_version="$(
+				printf "%s" "${available_factorio_versions}" |
+					jq --raw-output '.["core-linux64"][] | .to // empty' |
+					sort --version-sort |
+					tail --lines 1
+			)"
+			printf "Latest available Factorio version: %s\n" "${requested_factorio_version}"
+			;;
+		*)
+			requested_factorio_version="${FACTORIO_RELEASE}"
+			printf "Pinned Factorio version: %s\n" "${requested_factorio_version}"
+			;;
+		esac
+
+		if [[ "${requested_factorio_version}" == "${installed_factorio_version}" ]]; then
+			printf "Factorio is up to date (version: %s).\n" "${installed_factorio_version}"
+		else
+			printf "Update available: %s -> %s\n" "${installed_factorio_version}" "${requested_factorio_version}"
+
+			if [[ "${FACTORIO_AUTO_UPDATE,,}" =~ ^(true|1|yes)$ ]]; then
+				printf "Auto-update is enabled. Proceeding with update...\n"
+				download_factorio "${requested_factorio_version}"
+				printf "Update completed successfully.\n"
+			else
+				printf "Auto-update is disabled. Please enable it by setting 'FACTORIO_AUTO_UPDATE=true' if desired.\n"
+			fi
+		fi
+	fi
+}
+
+get_factorio_save() {
+	local downloaded_file_path="${MAPSHOT_WORKING_DIRECTORY}/$(basename "${FACTORIO_SAVE}")"
+	local save_file response http_status
+
+	if [[ "${MAPSHOT_SAVE_MODE}" == "latest" ]]; then
+		printf 'MAPSHOT_SAVE_MODE set to "latest". Discovering saves...\n'
+
+		if [[ ! -d "${FACTORIO_SAVE_PATH}" ]]; then
+			printf "Error: FACTORIO_SAVE_PATH '%s' does not exist or is not a directory.\n" "${FACTORIO_SAVE_PATH}"
+			exit 1
+		fi
+
+		save_file=$(find "${FACTORIO_SAVE_PATH}" -type f -exec ls --sort=time {} + 2>/dev/null | head -n 1) || {
+			printf "No save files found.\n"
+			sleep 30
+			continue
+		}
+		printf "Using latest save: '%s'\n" "${save_file}"
+	else
+		if [[ -z "${FACTORIO_SAVE:-}" ]]; then
+			printf "No save file specified and MAPSHOT_SAVE_MODE is not 'latest'.\n"
+			exit 1
+		fi
+
+		if [[ "${FACTORIO_SAVE}" =~ ^https?:// ]]; then
+			printf "Downloading save file from URL: %s\n" "${FACTORIO_SAVE}"
+
+			response=$(curl --location --silent --write-out "%{http_code}" --output "${downloaded_file_path}" "${FACTORIO_SAVE}")
+			http_status="${response: -3}"
+
+			if [[ "${http_status}" -ne 200 ]]; then
+				printf "Error: Received HTTP status '%s' while downloading save file.\n" "${http_status}"
+				exit 1
+			fi
+
+			if [[ ! "${downloaded_file_path}" =~ \.zip$ ]]; then
+				printf "Error: Downloaded file '%s' is not a .zip file. Exiting...\n" "${downloaded_file_path}"
+				rm --force "${downloaded_file_path}"
+				exit 1
+			fi
+
+			printf "Save file downloaded to: %s\n" "${downloaded_file_path}"
+			save_file="${downloaded_file_path}"
+		else
+			if [[ ! -f "${FACTORIO_SAVE}" ]]; then
+				printf "Error: Specified save file '%s' does not exist.\n" "${FACTORIO_SAVE}"
+				exit 1
+			fi
+
+			save_file="${FACTORIO_SAVE}"
+		fi
+	fi
+
+	printf "%s\n" "${save_file}"
+}
+
+render_mapshot() {
+	local save_file="${1}"
+
+	FACTORIO_VERBOSE_ARG=""
+	if [[ "${MAPSHOT_VERBOSE_FACTORIO_LOGGING,,}" =~ ^(true|1|yes)$ ]]; then
+		FACTORIO_VERBOSE_ARG="--factorio_verbose"
+	fi
+
+	timeout --preserve-status --kill-after 10 --verbose "${MAPSHOT_INTERVAL}" \
+		xvfb-run --server-args '-terminate' mapshot render \
+		--logtostderr \
+		--factorio_binary "${MAPSHOT_FACTORIO_BINARY_PATH}" \
+		--factorio_datadir "${MAPSHOT_FACTORIO_DATA_DIRECTORY}" \
+		--factorio_scriptoutput "${MAPSHOT_FACTORIO_SCRIPT_OUTPUT_DIRECTORY}" \
+		--work_dir "${MAPSHOT_WORKING_DIRECTORY}" \
+		--prefix "${MAPSHOT_PREFIX}" \
+		--area "${MAPSHOT_AREA:-all}" \
+		--tilemin "${MAPSHOT_MINIMUM_TILES:-64}" \
+		--tilemax "${MAPSHOT_MAXIMUM_TILES:-0}" \
+		--jpgquality "${MAPSHOT_JPEG_QUALITY:-90}" \
+		--minjpgquality "${MAPSHOT_MINIMUM_JPEG_QUALITY:-90}" \
+		--surface "${MAPSHOT_SURFACES_TO_RENDER:-_all_}" \
+		${FACTORIO_VERBOSE_ARG} \
+		-v "${MAPSHOT_VERBOSE_MAPSHOT_LOG_LEVEL_INT:-9}" \
+		"${save_file}"
+}
+
+move_generated_mapshot() {
+	local mapshot_save_path="${1}"
+	local mapshot_directory_name="${2}"
+	local factorio_save_file_name="${3}"
+	local mapshot_json
+
+	printf "Moving generated mapshot to '%s'...\n" "${mapshot_save_path}"
+
+	mkdir --parents "${mapshot_save_path}"
+	mv "${MAPSHOT_OUTPUT_DIRECTORY}/${factorio_save_file_name}"/* "${mapshot_save_path}"
+
+	find "${mapshot_save_path}" -mindepth 2 -maxdepth 2 -type f -name "mapshot.json" |
+		while read -r mapshot_json; do
+			jq --arg savename "${MAPSHOT_SAVE_NAME}" '.savename = $savename' "${mapshot_json}" >"${mapshot_json}.tmp" &&
+				mv "${mapshot_json}.tmp" "${mapshot_json}"
+		done
+}
+
+cleanup_old_mapshots() {
+	local mapshot_save_path="${1}"
+
+	if [[ -d "${mapshot_save_path}" ]]; then
+		printf "Cleaning up old d-* directories...\n"
+
+		find "${mapshot_save_path}" -maxdepth 1 -type d -name "d-*" |
+			sort --reverse | tail --lines +2 |
+			while read -r dir; do
+				printf "Removing directory: '%s'\n" "${dir}"
+				rm --recursive --force "${dir}"
+			done
+
+		printf "Cleanup complete.\n"
+	else
+		printf "No previous mapshot directories to clean in '%s'.\n" "${mapshot_save_path}"
+	fi
+}
+
+case "${MAPSHOT_MODE}" in
+"render")
+	printf 'Mapshot mode set to "render".\n'
+	check_factorio_installation
+
+	printf "Starting Mapshot loop with timeout of %s seconds...\n" "${MAPSHOT_INTERVAL}"
+	while true; do
+		factorio_save_file_path="$(get_factorio_save | tail --lines 1)"
+		factorio_save_file_name=$(basename "${factorio_save_file_path}" .zip)
+		factorio_md5_file="${MAPSHOT_ROOT_DIRECTORY}/${factorio_save_file_name}.md5"
+		current_md5=$(calculate_md5 "${factorio_save_file_path}")
+		previous_md5=$(cat "${factorio_md5_file}" 2>/dev/null || printf "\n")
+
+		if [[ "${current_md5}" != "${previous_md5}" ]]; then
+			mapshot_directory_name="${MAPSHOT_SAVE_NAME:-"${factorio_save_file_name}"}"
+			mapshot_save_path="${MAPSHOT_OUTPUT_DIRECTORY}/${mapshot_directory_name}"
+
+			printf "Rendering mapshot...\n"
+			render_mapshot "${factorio_save_file_path}"
+			printf "%s" "${current_md5}" >"${factorio_md5_file}"
+
+			if [[ -n "${MAPSHOT_SAVE_NAME}" && "${mapshot_directory_name}" != "${factorio_save_file_name}" ]]; then
+				move_generated_mapshot "${mapshot_save_path}" "${mapshot_directory_name}" "${factorio_save_file_name}"
+			fi
+
+			if [[ "${MAPSHOT_KEEP_ONLY_LATEST,,}" =~ ^(true|1|yes)$ ]]; then
+				cleanup_old_mapshots "${mapshot_save_path}"
+			fi
+		else
+			printf "No changes in the save file. Skipping render.\n"
+			sleep 30
+		fi
+	done
+	;;
+"serve")
+	printf 'Mapshot mode set to "serve".\n'
+
+	while true; do
+		if [[ -d "${MAPSHOT_OUTPUT_DIRECTORY}" ]]; then
+			printf 'Serving mapshot...\n'
+
+			mapshot serve \
+				--factorio_scriptoutput "${MAPSHOT_FACTORIO_SCRIPT_OUTPUT_DIRECTORY}" \
+				--work_dir "${MAPSHOT_WORKING_DIRECTORY}" \
+				-v "${MAPSHOT_VERBOSE_MAPSHOT_LOG_LEVEL_INT:-9}" || {
+				printf "Mapshot serve operation failed.\n"
+				exit 1
+			}
+
+			break
+		else
+			printf "Script output directory '%s' does not exist.\n" "${MAPSHOT_OUTPUT_DIRECTORY}"
+			sleep 30
+		fi
+	done
+	;;
+*)
+	printf 'Invalid MAPSHOT_MODE. Please set it to "render" or "serve". Exiting...\n'
+	exit 1
+	;;
+esac
+
+printf "Mapshot successfully completed.\n"
+exit 0


### PR DESCRIPTION
I have rewritten the `entrypoint.sh` for more flexibility and readability because it got messy with the new features which hopefully results in a more maintainable codebase.
Updated the `README.md` accordingly.
Additionally i have updated the `Dockerfile` to run rootless.

general improvements:
- running rootless
- dont rely on container crashes on `timeout` - loop around

new options:
- download fixed or automatically discovered factorio releases
- auto-update factorio
- supporting `http(s)://` addresses as factorio save path
- renaming generated mapshot
- keep only latest generated mapshot - credits: #2 

breaking:
- `/mapshot` is moved to `/opt/mapshot` for more similarity with `factoriotools/factorio-docker`
